### PR TITLE
fix audio negotiation for non-numeric user ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Node dependencies
+node_modules/
+frontend/node_modules/
+
+# Python cache
+__pycache__/
+backend/**/__pycache__/
+**/*.pyc
+
+# Logs and database
+logs/
+*.log
+cinemate.db
+
+# Test caches
+.tests_cache/
+tests/__pycache__/
+

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -311,7 +311,12 @@ export default function VideoPlayer({ roomId, username, userId }) {
         setMicOn(true);
         for (const u of users) {
           if (u.id === myUserId) continue;
-          if (Number(myUserId) > Number(u.id)) continue;
+          // Ensure consistent ordering for peer connection initiation.
+          // User IDs are UUID strings, so numeric comparison fails (NaN),
+          // resulting in both peers trying to create offers simultaneously.
+          // Use string comparison instead to deterministically choose one
+          // initiator per pair and avoid negotiation glare.
+          if (String(myUserId) > String(u.id)) continue;
           let pc = peersRef.current[u.id];
           if (!pc) {
             pc = createPeerConnection(u.id);
@@ -344,7 +349,9 @@ export default function VideoPlayer({ roomId, username, userId }) {
       try {
         for (const u of users) {
           if (u.id === myUserId) continue;
-          if (Number(myUserId) > Number(u.id)) continue;
+          // Same ordering logic as in toggleMic: compare IDs as strings
+          // to decide which peer should create the offer.
+          if (String(myUserId) > String(u.id)) continue;
           if (!peersRef.current[u.id]) {
             const pc = createPeerConnection(u.id);
             peersRef.current[u.id] = pc;


### PR DESCRIPTION
## Summary
- handle peer negotiation with string user IDs to avoid double offer glare
- add .gitignore for dependencies, caches, logs

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6894518c41148323924a4fd103867146