### PR TITLE
feat: enable room creation and sharing

### DIFF
--- a/backend/api/rooms.py
+++ b/backend/api/rooms.py
@@ -13,7 +13,7 @@ def create_room(db: Session = Depends(get_db)):
     """Create a new room and persist it to the database."""
 
     room = crud.create_room(db)
-    return {"room_id": room.id}
+    return {"room_id": room.id, "room_url": f"/?room={room.id}"}
 
 
 @router.get("/{room_id}")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   ThemeProvider,
   createTheme,
@@ -6,7 +6,6 @@ import {
   Box,
   Paper,
   Typography,
-  TextField,
   Button,
 } from "@mui/material";
 import TelegramLogin from "./components/TelegramLogin";
@@ -32,13 +31,28 @@ const darkTheme = createTheme({
 });
 
 export default function App() {
-  const [roomId, setRoomId] = useState("");
+  const [roomId, setRoomId] = useState(() =>
+    new URLSearchParams(window.location.search).get("room") || ""
+  );
   const [user, setUser] = useState(null);
   const [joined, setJoined] = useState(false);
 
-  const handleJoin = () => {
-    if (roomId.trim() && user) {
+  useEffect(() => {
+    if (user && roomId) {
       setJoined(true);
+    }
+  }, [user, roomId]);
+
+  const createRoom = async () => {
+    try {
+      const resp = await fetch("/api/rooms/create", { method: "POST" });
+      const data = await resp.json();
+      setRoomId(data.room_id);
+      setJoined(true);
+      const newUrl = `${window.location.pathname}?room=${data.room_id}`;
+      window.history.replaceState(null, "", newUrl);
+    } catch (err) {
+      console.error("Failed to create room", err);
     }
   };
 
@@ -79,24 +93,16 @@ export default function App() {
             ) : !joined ? (
               <>
                 <Typography variant="h4" align="center" gutterBottom fontWeight={600}>
-                  Join Room
+                  Создать комнату
                 </Typography>
-                <TextField
-                  fullWidth
-                  label="Room ID"
-                  variant="outlined"
-                  value={roomId}
-                  onChange={(e) => setRoomId(e.target.value)}
-                  sx={{ mt: 2 }}
-                />
                 <Button
                   fullWidth
                   variant="contained"
                   size="large"
                   sx={{ mt: 3, fontWeight: 600 }}
-                  onClick={handleJoin}
+                  onClick={createRoom}
                 >
-                  Join
+                  Создать
                 </Button>
               </>
             ) : (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,6 @@ import {
   Box,
   Paper,
   Typography,
-  Button,
 } from "@mui/material";
 import TelegramLogin from "./components/TelegramLogin";
 import VideoPlayer from "./components/VideoPlayer";
@@ -37,24 +36,29 @@ export default function App() {
   const [user, setUser] = useState(null);
   const [joined, setJoined] = useState(false);
 
-  useEffect(() => {
-    if (user && roomId) {
-      setJoined(true);
-    }
-  }, [user, roomId]);
-
   const createRoom = async () => {
     try {
       const resp = await fetch("/api/rooms/create", { method: "POST" });
       const data = await resp.json();
       setRoomId(data.room_id);
-      setJoined(true);
-      const newUrl = `${window.location.pathname}?room=${data.room_id}`;
+      const newUrl = data.room_url || `${window.location.pathname}?room=${data.room_id}`;
       window.history.replaceState(null, "", newUrl);
     } catch (err) {
       console.error("Failed to create room", err);
     }
   };
+
+  useEffect(() => {
+    if (user && !roomId) {
+      createRoom();
+    }
+  }, [user, roomId]);
+
+  useEffect(() => {
+    if (user && roomId) {
+      setJoined(true);
+    }
+  }, [user, roomId]);
 
   return (
     <ThemeProvider theme={darkTheme}>
@@ -91,20 +95,9 @@ export default function App() {
                 <TelegramLogin onAuthSuccess={setUser} />
               </>
             ) : !joined ? (
-              <>
-                <Typography variant="h4" align="center" gutterBottom fontWeight={600}>
-                  Создать комнату
-                </Typography>
-                <Button
-                  fullWidth
-                  variant="contained"
-                  size="large"
-                  sx={{ mt: 3, fontWeight: 600 }}
-                  onClick={createRoom}
-                >
-                  Создать
-                </Button>
-              </>
+              <Typography variant="h5" align="center" fontWeight={600}>
+                Создание комнаты...
+              </Typography>
             ) : (
               <VideoPlayer roomId={roomId} username={user.name} userId={user.id} />
             )}

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -26,6 +26,8 @@ import VideoLibraryIcon from "@mui/icons-material/VideoLibrary";
 import CloseIcon from "@mui/icons-material/Close";
 import MicIcon from "@mui/icons-material/Mic";
 import MicOffIcon from "@mui/icons-material/MicOff";
+import LinkIcon from "@mui/icons-material/Link";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 
 import CustomVideoPlayer from "./CustomVideoPlayer";
 import ChatBox from "./ChatBox";
@@ -79,6 +81,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const roomLink = `${window.location.origin}${window.location.pathname}?room=${roomId}`;
 
   useEffect(() => {
     const ws = new WebSocket(
@@ -523,6 +526,10 @@ export default function VideoPlayer({ roomId, username, userId }) {
               <ListItemIcon><ChatIcon /></ListItemIcon>
               <ListItemText primary="Чат" />
             </ListItemButton>
+            <ListItemButton selected={activeTab === "share"} onClick={() => setActiveTab("share")}>
+              <ListItemIcon><LinkIcon /></ListItemIcon>
+              <ListItemText primary="Скопировать ссылку" />
+            </ListItemButton>
           </List>
 
           {isMobile && (
@@ -580,6 +587,25 @@ export default function VideoPlayer({ roomId, username, userId }) {
                 setInput={setChatInput}
                 onSend={handleSendChat}
               />
+            )}
+            {activeTab === "share" && (
+              <Box>
+                <Typography gutterBottom>Поделитесь ссылкой:</Typography>
+                <TextField
+                  fullWidth
+                  value={roomLink}
+                  InputProps={{ readOnly: true }}
+                  sx={{ mb: 2 }}
+                />
+                <Button
+                  variant="contained"
+                  fullWidth
+                  startIcon={<ContentCopyIcon />}
+                  onClick={() => navigator.clipboard.writeText(roomLink)}
+                >
+                  Скопировать
+                </Button>
+              </Box>
             )}
           </Box>
         </Box>

--- a/tests/test_rooms_api.py
+++ b/tests/test_rooms_api.py
@@ -20,7 +20,9 @@ def test_create_and_get_room():
     # Create a new room
     resp = client.post("/api/rooms/create")
     assert resp.status_code == 200
-    room_id = resp.json()["room_id"]
+    data = resp.json()
+    room_id = data["room_id"]
+    assert data["room_url"] == f"/?room={room_id}"
 
     # Retrieve the same room
     resp = client.get(f"/api/rooms/{room_id}")


### PR DESCRIPTION
## Summary
- allow backend to return room URL when creating a room
- enable room creation in the UI with shareable links
- add share tab in player menu to copy invitation link

## Testing
- `pytest -q`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_b_6894580499ec832396684cbcdba922e9