### PR TITLE
Add LiveKit server service and configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+TELEGRAM_BOT_TOKEN=changeme
+LIVEKIT_API_KEY=changeme
+LIVEKIT_API_SECRET=changeme
+LIVEKIT_URL=http://livekit:7880
+

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,6 +8,9 @@ LOG_DIR = os.path.join(BASE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 SQLALCHEMY_DATABASE_URL = "sqlite:///./cinemate.db"
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+LIVEKIT_API_KEY = os.getenv("LIVEKIT_API_KEY")
+LIVEKIT_API_SECRET = os.getenv("LIVEKIT_API_SECRET")
+LIVEKIT_URL = os.getenv("LIVEKIT_URL")
 
 LOG_FILE = os.path.join(LOG_DIR, "cinemate.log")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,17 @@ services:
     build: ./backend
     environment:
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      LIVEKIT_API_KEY: ${LIVEKIT_API_KEY}
+      LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
+      LIVEKIT_URL: ${LIVEKIT_URL}
+    depends_on:
+      - livekit
+  livekit:
+    image: livekit/livekit-server
+    ports:
+      - "7880:7880"
+    command: >
+      --dev
+      --no-tls
+      --api-key ${LIVEKIT_API_KEY}
+      --api-secret ${LIVEKIT_API_SECRET}


### PR DESCRIPTION
## Summary
- Add LiveKit server service to docker-compose
- Introduce LiveKit environment variables in backend config and .env

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894744612d883239b11ce0c8d9178c0