### PR TITLE
feat: add voice service abstraction

### DIFF
--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -33,11 +33,7 @@ import CustomVideoPlayer from "./CustomVideoPlayer";
 import ChatBox from "./ChatBox";
 import ParticipantsList from "./ParticipantsList";
 import { WS_BASE_URL, API_BASE_URL } from "../config";
-import {
-  connectToRoom,
-  toggleMute as livekitToggleMute,
-  disconnect as livekitDisconnect,
-} from "../services/livekitClient";
+import voiceService from "../services/voiceService";
 
 function RemoteAudio({ stream }) {
   const audioRef = useRef(null);
@@ -195,7 +191,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
 
     return () => {
       ws.close();
-      livekitDisconnect();
+      voiceService.disconnect();
       setRemoteAudios([]);
       stopMicLevelMonitoring();
     };
@@ -280,7 +276,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
           }),
         });
         const { token, url } = await res.json();
-        const track = await connectToRoom(url, token, {
+        const track = await voiceService.connect(url, token, {
           onTrackSubscribed: (id, stream) => {
             setRemoteAudios((prev) => {
               const exists = prev.find((a) => a.id === id);
@@ -304,7 +300,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
         );
       }
     } else {
-      const isMuted = await livekitToggleMute();
+      const isMuted = await voiceService.toggleMute();
       setMuted(isMuted);
       if (isMuted) {
         stopMicLevelMonitoring();

--- a/frontend/src/services/voiceService.js
+++ b/frontend/src/services/voiceService.js
@@ -1,0 +1,60 @@
+import { connectToRoom, toggleMute as livekitToggleMute, disconnect as livekitDisconnect } from './livekitClient';
+
+class VoiceService {
+  constructor() {
+    this.useLegacy = false;
+    this.localStream = null;
+    this.localTrack = null;
+  }
+
+  async connect(url, token, callbacks) {
+    if (this.useLegacy) {
+      return this.legacyConnect();
+    }
+    this.localTrack = await connectToRoom(url, token, callbacks);
+    return this.localTrack;
+  }
+
+  async toggleMute() {
+    if (this.useLegacy) {
+      return this.legacyToggleMute();
+    }
+    return livekitToggleMute();
+  }
+
+  async disconnect() {
+    if (this.useLegacy) {
+      return this.legacyDisconnect();
+    }
+    await livekitDisconnect();
+    this.localTrack = null;
+  }
+
+  async fallbackToLegacy() {
+    await this.disconnect();
+    this.useLegacy = true;
+  }
+
+  async legacyConnect() {
+    if (!this.localStream) {
+      this.localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    }
+    return this.localStream.getAudioTracks()[0];
+  }
+
+  async legacyToggleMute() {
+    if (!this.localStream) return true;
+    const track = this.localStream.getAudioTracks()[0];
+    track.enabled = !track.enabled;
+    return !track.enabled;
+  }
+
+  async legacyDisconnect() {
+    if (this.localStream) {
+      this.localStream.getTracks().forEach((t) => t.stop());
+      this.localStream = null;
+    }
+  }
+}
+
+export default new VoiceService();


### PR DESCRIPTION
## Summary
- add VoiceService with LiveKit and legacy WebRTC fallback
- replace direct LiveKit calls with VoiceService in VideoPlayer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689481e804448323a82e1fe9b69ee4e4