### PR TITLE
docs: add LiveKit setup and migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,31 @@
 # Cinemate
 
+## LiveKit server
+
+The project uses [LiveKit](https://livekit.io) for voice chat. To run the server locally:
+
+1. Define the environment variables:
+   - `LIVEKIT_API_KEY` – API key for the server.
+   - `LIVEKIT_API_SECRET` – API secret used for signing tokens.
+   - `LIVEKIT_URL` – WebSocket URL of the LiveKit server (for example, `ws://localhost:7880`).
+   - `LIVEKIT_METRICS_URL` – optional metrics endpoint (default `http://livekit:7880/metrics`).
+   - `USE_LIVEKIT` – set to `true` to enable LiveKit in the backend.
+   - `VITE_USE_LIVEKIT` – set to `true` when building the frontend to enable LiveKit.
+2. Start the LiveKit server and backend via docker:
+
+```bash
+LIVEKIT_API_KEY=devkey \
+LIVEKIT_API_SECRET=devsecret \
+LIVEKIT_URL=ws://localhost:7880 \
+docker compose up livekit backend
+```
+
+The server runs on port `7880` in development mode without TLS.
+
 ## Manual reproduction steps for WebSocket disconnect
 
 1. Run the backend server and frontend.
 2. Open the application and connect to a room.
 3. Stop the backend or block the connection before any WebSocket message is received.
 4. Observe the browser console: a warning `WebSocket closed without kicked message` should appear, confirming the close handler runs even when no messages were processed.
+

--- a/docs/voice_chat_migration.md
+++ b/docs/voice_chat_migration.md
@@ -1,0 +1,26 @@
+# Миграция на LiveKit
+
+Этот документ описывает переход голосового чата проекта на LiveKit.
+
+## Отличия
+
+- Для голосового чата используется отдельный сервер LiveKit.
+- Аутентификация клиентов осуществляется по токенам, подписанным `LIVEKIT_API_SECRET`.
+- Появились новые переменные окружения: `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`,
+  `LIVEKIT_URL`, `LIVEKIT_METRICS_URL`, `USE_LIVEKIT` и `VITE_USE_LIVEKIT`.
+
+## Шаги перехода
+
+1. Запустить сервер LiveKit и убедиться, что он доступен по `LIVEKIT_URL`.
+2. Задать перечисленные переменные окружения для backend и frontend.
+3. Собрать frontend с `VITE_USE_LIVEKIT=true`.
+4. Перезапустить сервисы, чтобы они использовали LiveKit.
+
+## Откат
+
+Если возникли проблемы, можно вернуться к предыдущей реализации:
+
+1. Установить `USE_LIVEKIT=false` и пересобрать frontend с `VITE_USE_LIVEKIT=false`.
+2. Удалить переменные `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `LIVEKIT_URL` и `LIVEKIT_METRICS_URL`.
+3. Перезапустить сервисы без LiveKit.
+


### PR DESCRIPTION
## Summary
- document LiveKit server setup and environment variables
- add LiveKit migration and rollback guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894953257c48323948d769b90c6512e