### PR TITLE
fix: generate usable livekit url for clients

### DIFF
--- a/backend/routers/livekit.py
+++ b/backend/routers/livekit.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
+from urllib.parse import urlparse, urlunparse
 
 from backend.livekit.token_service import create_livekit_token
 from backend.config import LIVEKIT_URL
@@ -14,6 +15,16 @@ class TokenRequest(BaseModel):
 
 
 @router.post("/livekit/token")
-def generate_token(req: TokenRequest):
+def generate_token(req: TokenRequest, request: Request):
     token = create_livekit_token(req.user_id, req.room_id, req.role)
-    return {"token": token, "url": LIVEKIT_URL}
+
+    url = LIVEKIT_URL
+    if url:
+        parsed = urlparse(url)
+        if parsed.hostname == "livekit":
+            host = request.headers.get("host", "")
+            hostname = host.split(":")[0] if host else "localhost"
+            netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
+            url = urlunparse(parsed._replace(netloc=netloc))
+
+    return {"token": token, "url": url}

--- a/tests/backend/test_livekit_token.py
+++ b/tests/backend/test_livekit_token.py
@@ -46,6 +46,21 @@ def test_generate_token_success(monkeypatch):
     assert payload['video']['room'] == 'room1'
 
 
+def test_generate_token_rewrites_livekit_host(monkeypatch):
+    monkeypatch.setenv('LIVEKIT_API_KEY', 'test_key')
+    monkeypatch.setenv('LIVEKIT_API_SECRET', 'test_secret')
+    monkeypatch.setenv('LIVEKIT_URL', 'ws://livekit:7880')
+
+    _reload_backend()
+    from backend.main import app
+    client = TestClient(app)
+
+    resp = client.post('/livekit/token', json={'user_id': 'u1', 'room_id': 'room1'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['url'] == 'ws://testserver:7880'
+
+
 def test_generate_token_unknown_role(monkeypatch):
     monkeypatch.setenv('LIVEKIT_API_KEY', 'test_key')
     monkeypatch.setenv('LIVEKIT_API_SECRET', 'test_secret')


### PR DESCRIPTION
## Summary
- replace internal `livekit` hostname with request host in /livekit/token endpoint
- add regression test for LiveKit URL rewrite

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894b0fcdc0883239ebc054722faf019