### PR TITLE
Use room-based LiveKit config flag

### DIFF
--- a/backend/routers/config_router.py
+++ b/backend/routers/config_router.py
@@ -8,10 +8,15 @@ router = APIRouter()
 
 
 @router.get("/config")
-def get_client_config(user_id: str | None = Query(default=None)):
+def get_client_config(room_id: str | None = Query(default=None)):
+    """Return client configuration.
+
+    The LiveKit usage flag is determined globally by ``USE_LIVEKIT`` and, when
+    enabled, consistently for everyone in the same room based on ``room_id``.
+    """
     use_livekit = USE_LIVEKIT
-    if USE_LIVEKIT and user_id:
-        digest = hashlib.sha256(user_id.encode()).hexdigest()
+    if USE_LIVEKIT and room_id:
+        digest = hashlib.sha256(room_id.encode()).hexdigest()
         use_livekit = int(digest, 16) % 2 == 0
     return {"use_livekit": use_livekit}
 

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -97,7 +97,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
     async function loadConfig() {
       try {
         const res = await fetch(
-          `${API_BASE_URL}/config?user_id=${userId || ""}`
+          `${API_BASE_URL}/config?room_id=${roomId || ""}`
         );
         const data = await res.json();
         setUseLivekit(data.use_livekit);
@@ -106,7 +106,7 @@ export default function VideoPlayer({ roomId, username, userId }) {
       }
     }
     loadConfig();
-  }, [userId]);
+  }, [roomId]);
 
   useEffect(() => {
     voiceService.useLegacy = !useLivekit;

--- a/tests/test_config_router.py
+++ b/tests/test_config_router.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+# Ensure project root is on sys.path for module imports
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.main import app
+from backend.routers import config_router
+
+
+def test_same_room_receives_same_use_livekit():
+    """Two requests for the same room should return identical flags."""
+    # Force LiveKit logic to be active so the room_id is used
+    config_router.USE_LIVEKIT = True
+
+    with TestClient(app) as client:
+        resp1 = client.get("/config", params={"room_id": "room_a"})
+        resp2 = client.get("/config", params={"room_id": "room_a"})
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        assert resp1.json()["use_livekit"] == resp2.json()["use_livekit"]
+


### PR DESCRIPTION
## Summary
- determine LiveKit usage per room in `/config`
- frontend loads config using `roomId` for consistent flag
- add test ensuring same room gets same `use_livekit` value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6894b81f62a483239df34a526b7bf48e